### PR TITLE
Added ROS2 Humble functionality.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,65 @@ else()
   message(FATAL_ERROR "Unknown System Architecture: ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 
+# Check if being built with colcon
+if(DEFINED ENV{COLCON_CURRENT_PREFIX})
+  # Define ROS2 macro
+  add_definitions(-DROS2)
+
+  # ROS2 specific setup
+  find_package(geometry_msgs REQUIRED)
+  find_package(trossen_slate_msgs REQUIRED)
+  find_package(nav_msgs REQUIRED)
+  find_package(rclcpp REQUIRED)
+  find_package(sensor_msgs REQUIRED)
+  find_package(std_msgs REQUIRED)
+  find_package(std_srvs REQUIRED)
+  find_package(tf2_geometry_msgs REQUIRED)
+  find_package(tf2_ros REQUIRED)
+
+  set(ROS_DEPENDENCIES
+    geometry_msgs
+    trossen_slate_msgs
+    nav_msgs
+    rclcpp
+    sensor_msgs
+    std_msgs
+    std_srvs
+    tf2_geometry_msgs
+    tf2_ros
+  )
+
+  ament_target_dependencies(${PROJECT_NAME} ${ROS_DEPENDENCIES})
+
+  # Add the SLATE node executable
+  add_executable(trossen_slate_node
+    src/trossen_slate_node.cpp
+  )
+  target_link_libraries(trossen_slate_node PRIVATE ${PROJECT_NAME})
+
+  # Set rpath to include the directory where the shared library is installed
+  set_target_properties(trossen_slate_node PROPERTIES
+    INSTALL_RPATH "\$ORIGIN/../lib"
+    BUILD_WITH_INSTALL_RPATH TRUE
+  )
+
+  # Install ROS node
+  install(
+    TARGETS
+      trossen_slate_node
+    RUNTIME DESTINATION
+      lib/${PROJECT_NAME}
+  )
+
+  ament_package()
+endif()
+
 # Add the library
 add_library(${PROJECT_NAME} STATIC
   src/trossen_slate.cpp
   src/base_driver.cpp
 )
+
 target_include_directories(${PROJECT_NAME} PUBLIC include ${PROJECT_BINARY_DIR}/include)
 
 # Set the library to be position independent so that it can be linked to a shared library
@@ -34,7 +88,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 )
 
 # Link the serial driver library
-target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/lib/${ARCH}/libchassis_driver.so)
+target_link_libraries(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/lib/${ARCH}/libchassis_driver.so)
 
 # Add the demo executables
 add_executable(advanced_demo demo/advanced_demo.cpp)
@@ -43,11 +97,27 @@ target_link_libraries(advanced_demo PRIVATE ${PROJECT_NAME})
 add_executable(basic_demo demo/basic_demo.cpp)
 target_link_libraries(basic_demo PRIVATE ${PROJECT_NAME})
 
+# Set rpath to include the directory where the shared library is installed
+set_target_properties(advanced_demo PROPERTIES
+  INSTALL_RPATH "\$ORIGIN/../lib"
+  BUILD_WITH_INSTALL_RPATH TRUE
+)
+
+set_target_properties(basic_demo PROPERTIES
+  INSTALL_RPATH "\$ORIGIN/../lib"
+  BUILD_WITH_INSTALL_RPATH TRUE
+)
+
 # Install the library and executables
-install(DIRECTORY include/trossen_slate DESTINATION ${PROJECT_BINARY_DIR}/include)
+install(DIRECTORY include/trossen_slate DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
 install(TARGETS ${PROJECT_NAME} advanced_demo basic_demo
-  ARCHIVE DESTINATION ${PROJECT_BINARY_DIR}/lib
-  RUNTIME DESTINATION ${PROJECT_BINARY_DIR}/bin
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+  RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+)
+
+# Install the shared library
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/lib/${ARCH}/libchassis_driver.so
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
 )
 
 if(DEFINED SKBUILD)

--- a/include/trossen_slate/trossen_slate.hpp
+++ b/include/trossen_slate/trossen_slate.hpp
@@ -33,6 +33,20 @@
 #include <string>
 #include <vector>
 
+#ifdef ROS2
+#include "geometry_msgs/msg/quaternion.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "trossen_slate_msgs/srv/set_light_state.hpp"
+#include "trossen_slate_msgs/srv/set_string.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/battery_state.hpp"
+#include "std_srvs/srv/set_bool.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "tf2_ros/transform_broadcaster.h"
+#endif
+
 #include "trossen_slate/base_driver.hpp"
 #include "trossen_slate/serial_driver.hpp"
 
@@ -65,16 +79,40 @@ namespace trossen_slate
 #define MAX_VEL_X 1.0f
 #define MAX_VEL_Z 1.0f
 
+#ifdef ROS2
+using geometry_msgs::msg::Quaternion;
+using geometry_msgs::msg::TransformStamped;
+using geometry_msgs::msg::Twist;
+using nav_msgs::msg::Odometry;
+using sensor_msgs::msg::BatteryState;
+using std_srvs::srv::SetBool;
+using trossen_slate_msgs::srv::SetLightState;
+using trossen_slate_msgs::srv::SetString;
+#endif
+
 class TrossenSlate
+#ifdef ROS2
+  : public rclcpp::Node
+#endif
 {
 public:
+#ifdef ROS2
   /**
-   * @brief Constructor for TrossenSlate
+   * @brief Constructor for the TrossenSlate
+   * @param options ROS NodeOptions
    */
+  explicit TrossenSlate(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+#else
   TrossenSlate();
+#endif
 
   /// @brief Destructor for TrossenSlate
   ~TrossenSlate() {}
+
+#ifdef ROS2
+  /// @brief Process velocity commands and update robot state
+  void update();
+#endif
 
   /**
    * @brief Read data from the SLATE base
@@ -167,14 +205,127 @@ public:
   float get_voltage();
 
 private:
+#ifdef ROS2
+
+  // Update counter used to only update some values less frequently
+  int cnt_;
+
+  // Whether or not to publish TF from base_link->odom
+  bool publish_tf_;
+
+  // Whether or not we have received our first odometry update
+  bool is_first_odom_;
+
+  // Array containing x and y translation in meters and rotation in radians
+  float pose_[3];
+
+  // Name of odom frame
+  std::string odom_frame_name_;
+
+  // Name of base frame
+  std::string base_frame_name_;
+
+  // Time of the current update
+  rclcpp::Time current_time_;
+
+  // Odometry publisher
+  rclcpp::Publisher<Odometry>::SharedPtr pub_odom_;
+
+  // BatteryState publisher
+  rclcpp::Publisher<BatteryState>::SharedPtr pub_battery_state_;
+
+  // Twist command subscriber
+  rclcpp::Subscription<Twist>::SharedPtr sub_cmd_vel_;
+
+  // Set screen text service server
+  rclcpp::Service<SetString>::SharedPtr srv_set_text_;
+
+  // Motor status service server
+  rclcpp::Service<SetBool>::SharedPtr srv_motor_torque_status_;
+
+  // Set charge enable service server
+  rclcpp::Service<SetBool>::SharedPtr srv_enable_charging_;
+
+  // Set light state service server
+  rclcpp::Service<SetLightState>::SharedPtr srv_set_light_state_;
+
+  // If publish_tf_ is true, this is the broadcaster used to publish the odom->base_link TF
+  tf2_ros::TransformBroadcaster tf_broadcaster_odom_;
+
+  /**
+   * @brief Process incoming Twist command message
+   * @param msg Incoming Twist command message
+   */
+  void cmd_vel_callback(const Twist::SharedPtr msg);
+
+  /**
+   * @brief Process incoming screen text service request
+   * @param request_header Incoming RMW request identifier
+   * @param req Service request containing desired text
+   * @param res[out] Service response containing a success indication and a message
+   * @return true if service succeeded, false otherwise
+   */
+  bool set_text_callback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<SetString::Request> req,
+    const std::shared_ptr<SetString::Response> res);
+
+  /**
+   * @brief Process incoming motor torque status service request
+   * @param request_header Incoming RMW request identifier
+   * @param req Service request containing desired motor torque status
+   * @param res[out] Service response containing a success indication and a message
+   * @return true if service succeeded, false otherwise
+   */
+  bool motor_torque_status_callback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<SetBool::Request> req,
+    const std::shared_ptr<SetBool::Response> res);
+
+  /**
+   * @brief Process incoming enable charging service request
+   * @param request_header Incoming RMW request identifier
+   * @param req Service request containing desired charging enable status
+   * @param res[out] Service response containing a success indication and a message
+   * @return true if service succeeded, false otherwise
+   */
+  bool enable_charging_callback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<SetBool::Request> req,
+    const std::shared_ptr<SetBool::Response> res);
+
+  /**
+   * @brief Process incoming set light state service request
+   * @param request_header Incoming RMW request identifier
+   * @param req Service request containing desired light state
+   * @param res[out] Service response containing a success indication and a message
+   * @return true if service succeeded, false otherwise
+   */
+  bool set_light_state_callback(
+    const std::shared_ptr<rmw_request_id_t>/*request_header*/,
+    const std::shared_ptr<SetLightState::Request> req,
+    const std::shared_ptr<SetLightState::Response> res);
+
+  /**
+   * @brief Wrap angle
+   * @param angle Angle to wrap in radians
+   * @return Wrapped angle
+   */
+  float wrap_angle(float angle);
+
+#endif
+
   // Flag to keep track of base initialization
   bool base_initialized_ = false;
 
-  // Stored data of the SLATE base - see base_driver.hpp for details
-  base_driver::ChassisData data_;
+  // Base light state - see trossen_slate_msgs/srv/SetLightState for details
+  uint32_t light_state_ = 0;
 
   // Base command bytes containing data about charging and motor torque enabling
   uint32_t sys_cmd_ = 0;
+
+  // Stored data of the SLATE base - see base_driver.hpp for details
+  base_driver::ChassisData data_;
 };
 
 } // namespace trossen_slate

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>trossen_slate</name>
+  <version>1.0.0</version>
+  <description>The trossen_slate package</description>
+
+  <maintainer email="trsupport@trossenrobotics.com">Trossen Robotics</maintainer>
+
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>geometry_msgs</depend>
+  <depend>trossen_slate_msgs</depend>
+  <depend>libudev-dev</depend>
+  <depend>nav_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/trossen_slate.cpp
+++ b/src/trossen_slate.cpp
@@ -26,11 +26,203 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include <chrono>
+#include <iostream>
+
 #include "trossen_slate/trossen_slate.hpp"
 
 namespace trossen_slate
 {
 
+#ifdef ROS2
+TrossenSlate::TrossenSlate(const rclcpp::NodeOptions & options)
+: rclcpp::Node("trossen_slate", "", options), sys_cmd_{0},
+  publish_tf_(false), current_time_(get_clock()->now()), tf_broadcaster_odom_(this)
+{
+  using std::placeholders::_1, std::placeholders::_2, std::placeholders::_3;
+
+  declare_parameter<bool>("publish_tf", false);
+  declare_parameter<std::string>("odom_frame_name", "odom");
+  declare_parameter<std::string>("base_frame_name", "base_link");
+
+  get_parameter("publish_tf", publish_tf_);
+  get_parameter("odom_frame_name", odom_frame_name_);
+  get_parameter("base_frame_name", base_frame_name_);
+
+  pub_odom_ = create_publisher<Odometry>("odom", 50);
+  pub_battery_state_ = create_publisher<BatteryState>("battery_state", 1);
+
+  sub_cmd_vel_ = create_subscription<Twist>(
+    "cmd_vel",
+    1,
+    std::bind(&TrossenSlate::cmd_vel_callback, this, _1));
+
+  srv_set_text_ = create_service<SetString>(
+    "set_text",
+    std::bind(&TrossenSlate::set_text_callback, this, _1, _2, _3));
+
+  srv_motor_torque_status_ = create_service<SetBool>(
+    "set_motor_torque_status",
+    std::bind(&TrossenSlate::motor_torque_status_callback, this, _1, _2, _3));
+
+  srv_enable_charging_ = create_service<SetBool>(
+    "enable_charging",
+    std::bind(&TrossenSlate::enable_charging_callback, this, _1, _2, _3));
+
+  srv_set_light_state_ = create_service<SetLightState>(
+    "set_light_state",
+    std::bind(&TrossenSlate::set_light_state_callback, this, _1, _2, _3));
+
+  std::string dev;
+  if (!base_driver::chassisInit(dev)) {
+    RCLCPP_ERROR(get_logger(), "Failed to initialize base port.");
+    ::exit(EXIT_FAILURE);
+  }
+  RCLCPP_INFO(get_logger(), "Initalized base at port '%s'.", dev.c_str());
+  char version[32] = {0};
+  if (base_driver::getVersion(version)) {
+    RCLCPP_INFO(get_logger(), "Base version: %s", version);
+  }
+}
+
+void TrossenSlate::update()
+{
+  rclcpp::spin_some(get_node_base_interface());
+  current_time_ = get_clock()->now();
+
+  if (!base_driver::updateChassisInfo(&data_)) {
+    return;
+  }
+
+  // Update battery state every 10 iterations
+  cnt_++;
+  auto battery_state = BatteryState();
+  if (cnt_ % 10 == 0) {
+    battery_state.header.stamp = current_time_;
+    battery_state.voltage = data_.voltage;
+    battery_state.current = data_.current;
+    battery_state.percentage = data_.charge;
+    battery_state.power_supply_status = data_.system_state;
+    pub_battery_state_->publish(battery_state);
+  }
+
+  if (is_first_odom_) {
+    pose_[0] = data_.odom_x;
+    pose_[1] = data_.odom_y;
+    pose_[2] = data_.odom_z;
+    is_first_odom_ = false;
+  }
+
+  // Create transform
+  tf2::Quaternion q;
+  q.setRPY(0, 0, wrap_angle(data_.odom_z - pose_[2]));
+  auto odom_quat = tf2::toMsg(q);
+  auto odom_trans = TransformStamped();
+  odom_trans.header.stamp = current_time_;
+  odom_trans.header.frame_id = odom_frame_name_;
+  odom_trans.child_frame_id = base_frame_name_;
+
+  odom_trans.transform.translation.x =
+    cos(-pose_[2]) * (data_.odom_x - pose_[0]) - sin(-pose_[2]) * (data_.odom_y - pose_[1]);
+  odom_trans.transform.translation.y =
+    sin(-pose_[2]) * (data_.odom_x - pose_[0]) + cos(-pose_[2]) * (data_.odom_y - -pose_[1]);
+  odom_trans.transform.translation.z = 0.0;
+  odom_trans.transform.translation.z = 0.0;
+  odom_trans.transform.rotation = odom_quat;
+
+  // Send the transform
+  if (publish_tf_) {
+    tf_broadcaster_odom_.sendTransform(odom_trans);
+  }
+
+  // Publish odometry
+  auto odom = Odometry();
+  odom.header.stamp = current_time_;
+  odom.header.frame_id = odom_frame_name_;
+
+  // Set pose
+  odom.pose.pose.position.x = odom_trans.transform.translation.x;
+  odom.pose.pose.position.y = odom_trans.transform.translation.y;
+  odom.pose.pose.position.z = 0.0;
+  odom.pose.pose.orientation = odom_quat;
+  odom.pose.covariance[0] = (data_.system_state == SystemState::SYS_ESTOP) ? -1 : 1;
+
+  // Set cmd velocity
+  odom.child_frame_id = base_frame_name_;
+  odom.twist.twist.linear.x = data_.vel_x;
+  odom.twist.twist.linear.y = 0;
+  odom.twist.twist.angular.z = data_.vel_z;
+
+  pub_odom_->publish(odom);
+}
+
+void TrossenSlate::cmd_vel_callback(const Twist::SharedPtr msg)
+{
+  data_.cmd_vel_x = msg->linear.x;
+  data_.cmd_vel_z = msg->linear.z;
+}
+
+bool TrossenSlate::set_text_callback(
+  const std::shared_ptr<rmw_request_id_t>/*request_header*/,
+  const std::shared_ptr<SetString::Request> req,
+  const std::shared_ptr<SetString::Response> res)
+{
+  res->success = this->set_text(req->data);
+  res->message = "Set base screen text to: '" + req->data + "'.";
+  RCLCPP_INFO(get_logger(), res->message.c_str());
+  return true;
+}
+
+bool TrossenSlate::motor_torque_status_callback(
+  const std::shared_ptr<rmw_request_id_t>/*request_header*/,
+  const std::shared_ptr<SetBool::Request> req,
+  const std::shared_ptr<SetBool::Response> res)
+{
+  std::string result;
+  res->success = this->enable_motor_torque(req->data, result);
+  res->message = result;
+  RCLCPP_INFO(get_logger(), res->message.c_str());
+  return res->success;
+}
+
+bool TrossenSlate::enable_charging_callback(
+  const std::shared_ptr<rmw_request_id_t>/*request_header*/,
+  const std::shared_ptr<SetBool::Request> req,
+  const std::shared_ptr<SetBool::Response> res)
+{
+  std::string result;
+  res->success = this->enable_charging(req->data, result);
+  res->message = result;
+  RCLCPP_INFO(get_logger(), res->message.c_str());
+  return res->success;
+}
+
+bool TrossenSlate::set_light_state_callback(
+  const std::shared_ptr<rmw_request_id_t>/*request_header*/,
+  const std::shared_ptr<SetLightState::Request> req,
+  const std::shared_ptr<SetLightState::Response> res)
+{
+  // Cast the light_state from the request to the LightState enum class
+  LightState light_state = static_cast<LightState>(req->light_state);
+
+  // Call the set_light_state method with the casted light_state
+  res->success = this->set_light_state(light_state);
+  res->message = "Set light state to: " + std::to_string(req->light_state);
+  RCLCPP_INFO(get_logger(), res->message.c_str());
+  return true;
+}
+
+float TrossenSlate::wrap_angle(float angle)
+{
+  if (angle > M_PI) {
+    angle = angle - 2.0 * M_PI;
+  } else if (angle < -M_PI) {
+    angle = angle + 2.0 * M_PI;
+  }
+  return angle;
+}
+
+#endif
 TrossenSlate::TrossenSlate()
 : sys_cmd_{0}
 {

--- a/src/trossen_slate_node.cpp
+++ b/src/trossen_slate_node.cpp
@@ -1,0 +1,44 @@
+// Copyright 2025 Trossen Robotics
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the copyright holder nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <memory>
+
+#include "trossen_slate/trossen_slate.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<trossen_slate::TrossenSlate>();
+
+  auto r = rclcpp::Rate(20);
+
+  while (rclcpp::ok()) {
+    node->update();
+    r.sleep();
+  }
+}


### PR DESCRIPTION
Used macro for ROS2 to separate C++/Python usage. Created an update method for ROS2 similar to original but simplified and compatible with current variables. Tested with ROS2, C++, and Python. Set rpath in CMakeLists.txt to avoid having to set LD_LIBRARY_PATH. This will need to be set manually (such as put in bashrc) for users who use Python, so that the chassis driver shared object file can be found.