### PR TITLE
Allow for ROS-less builds, cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+.vscode/
+
 build/
+install/
+
+.venv/
 dist/
 __pycache__/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,12 +7,14 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 # Add compiler options for GCC and Clang
-if(CMAKE_COMPILER_IS_GNUXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-# Set the build type to Release
-set(CMAKE_BUILD_TYPE "Release")
+# Default to Release build type if not specified
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release")
+endif()
 
 # Define the serial driver library name
 set(serial_driver "chassis_driver")
@@ -26,9 +28,15 @@ else()
   message(FATAL_ERROR "Unknown System Architecture: ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 
-# Find the ament_cmake package if not building with scikit-build
+# Optionally find ament_cmake for ROS 2 builds (skip when building with scikit-build)
 if(NOT DEFINED SKBUILD)
-  find_package(ament_cmake REQUIRED)
+  find_package(ament_cmake QUIET)
+endif()
+
+if(ament_cmake_FOUND)
+  message(STATUS "ament_cmake found - building as a ROS 2 (ament) package")
+else()
+  message(STATUS "ament_cmake not found - building as a standalone CMake project")
 endif()
 
 # Include the version generation script
@@ -151,8 +159,8 @@ if(DEFINED SKBUILD)
   )
 endif()
 
-# If not building with scikit-build, export the ament package
-if(NOT DEFINED SKBUILD)
+# If ament is available, export the ament package
+if(ament_cmake_FOUND)
   ament_export_targets("export_${PROJECT_NAME}")
   ament_package()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,15 +66,19 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 # Link the serial driver library
 target_link_libraries(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/lib/${ARCH}/libchassis_driver.so)
 
-# Add the demo executables
-add_executable(advanced_demo demo/advanced_demo.cpp)
-target_link_libraries(advanced_demo PRIVATE ${PROJECT_NAME})
+# Optionally build demo executables
+option(BUILD_DEMOS "Build demo executables" OFF)
 
-add_executable(basic_demo demo/basic_demo.cpp)
-target_link_libraries(basic_demo PRIVATE ${PROJECT_NAME})
+if(BUILD_DEMOS)
+  add_executable(advanced_demo demo/advanced_demo.cpp)
+  target_link_libraries(advanced_demo PRIVATE ${PROJECT_NAME})
 
-add_executable(reset_odom_demo demo/reset_odom_demo.cpp)
-target_link_libraries(reset_odom_demo PRIVATE ${PROJECT_NAME})
+  add_executable(basic_demo demo/basic_demo.cpp)
+  target_link_libraries(basic_demo PRIVATE ${PROJECT_NAME})
+
+  add_executable(reset_odom_demo demo/reset_odom_demo.cpp)
+  target_link_libraries(reset_odom_demo PRIVATE ${PROJECT_NAME})
+endif()
 
 # Install the library headers
 install(DIRECTORY include/${PROJECT_NAME}/ DESTINATION include/${PROJECT_NAME})
@@ -105,13 +109,15 @@ install(
 )
 
 # Install the demo executables
-install(
-  TARGETS
-    advanced_demo
-    basic_demo
-    reset_odom_demo
-  RUNTIME DESTINATION bin
-)
+if(BUILD_DEMOS)
+  install(
+    TARGETS
+      advanced_demo
+      basic_demo
+      reset_odom_demo
+    RUNTIME DESTINATION bin
+  )
+endif()
 
 # Install the serial driver library
 install(

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+BUILD_DIR    := build
+INSTALL_DIR  := install
+NPROC        := $(shell nproc 2>/dev/null || echo 4)
+
+.PHONY: build install clean demo python help
+build:
+	@cmake --build $(BUILD_DIR) -j$(NPROC)
+
+install: build
+	@cmake --install $(BUILD_DIR)
+
+clean:
+	@rm -rf $(BUILD_DIR) $(INSTALL_DIR)
+
+demo: build
+	@./$(BUILD_DIR)/basic_demo
+
+python:
+	@pip install .
+
+help:
+	@echo "trossen_slate build targets:"
+	@echo ""
+	@echo "  make build        Build the project"
+	@echo "  make install      Build and install to ./install"
+	@echo "  make clean        Remove build/ and install/ directories"
+	@echo "  make demo         Build and run basic_demo"
+	@echo "  make python       Build and install the Python package"
+	@echo ""
+	@echo "Variables:"
+	@echo "  BUILD_DIR=...     Set build directory (default: build)"
+	@echo "  INSTALL_DIR=...   Set install prefix (default: install)"
+	@echo "  NPROC=...         Set number of parallel build jobs (default: number of CPU cores)"

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ NPROC        := $(shell nproc 2>/dev/null || echo 4)
 
 .PHONY: build install clean demo python help
 build:
+	@cmake -S . -B $(BUILD_DIR) -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR)
 	@cmake --build $(BUILD_DIR) -j$(NPROC)
 
 install: build
@@ -12,7 +13,9 @@ install: build
 clean:
 	@rm -rf $(BUILD_DIR) $(INSTALL_DIR)
 
-demo: build
+demo:
+	@cmake -S . -B $(BUILD_DIR) -DCMAKE_INSTALL_PREFIX=$(INSTALL_DIR) -DBUILD_DEMOS=ON
+	@cmake --build $(BUILD_DIR) -j$(NPROC)
 	@./$(BUILD_DIR)/basic_demo
 
 python:

--- a/demo/advanced_demo.cpp
+++ b/demo/advanced_demo.cpp
@@ -58,13 +58,8 @@ int main()
   std::cout << result_torque << std::endl;
 
   while (true) {
-    // Initialize data with angular velocity and light state
-    base_driver::ChassisData my_data{};
-    my_data.cmd_vel_z = -0.1;
-    my_data.light_state = static_cast<uint32_t>(LightState::WHITE);
-
-    // Write and update base data
-    slate.write(my_data);
+    // Update state to fetch fresh data from hardware
+    slate.update_state();
 
     // Initialize empty log data
     base_driver::ChassisData log_data;

--- a/demo/advanced_demo.cpp
+++ b/demo/advanced_demo.cpp
@@ -57,6 +57,12 @@ int main()
   slate.enable_motor_torque(true, result_torque);
   std::cout << result_torque << std::endl;
 
+  // Set angular velocity and light state
+  base_driver::ChassisData my_data{};
+  my_data.cmd_vel_z = -0.1;
+  my_data.light_state = static_cast<uint32_t>(LightState::WHITE);
+  slate.write(my_data);
+
   while (true) {
     // Update state to fetch fresh data from hardware
     slate.update_state();

--- a/demo/advanced_demo.cpp
+++ b/demo/advanced_demo.cpp
@@ -41,7 +41,10 @@ int main()
 
   // Initialize base and output result
   std::string result_init;
-  slate.init_base(result_init);
+  if (!slate.init_base(result_init)) {
+    std::cerr << result_init << std::endl;
+    return 1;
+  }
   std::cout << result_init << std::endl;
 
   // Disable charging and output result

--- a/demo/advanced_demo.cpp
+++ b/demo/advanced_demo.cpp
@@ -56,9 +56,9 @@ int main()
 
   while (true) {
     // Initialize data with angular velocity and light state
-    base_driver::ChassisData my_data = {
-      .cmd_vel_z = -0.1,
-      .light_state = static_cast<uint32_t>(LightState::WHITE)};
+    base_driver::ChassisData my_data{};
+    my_data.cmd_vel_z = -0.1;
+    my_data.light_state = static_cast<uint32_t>(LightState::WHITE);
 
     // Write and update base data
     slate.write(my_data);

--- a/demo/basic_demo.cpp
+++ b/demo/basic_demo.cpp
@@ -41,7 +41,10 @@ int main()
 
   // Initialize base and output result
   std::string result_init;
-  slate.init_base(result_init);
+  if (!slate.init_base(result_init)) {
+    std::cerr << result_init << std::endl;
+    return 1;
+  }
   std::cout << result_init << std::endl;
 
   // Display "Hello world" on screen

--- a/demo/basic_demo.cpp
+++ b/demo/basic_demo.cpp
@@ -50,12 +50,15 @@ int main()
   // Display "Hello world" on screen
   slate.set_text("Hello world");
 
-  while (true) {
-    // Set the LED colors to PURPLE
-    slate.set_light_state(LightState::PURPLE);
+  // Set the LED colors to PURPLE
+  slate.set_light_state(LightState::PURPLE);
 
-    // Set angular velocity to 0.1
-    slate.set_cmd_vel(0.0, 0.1);
+  // Set angular velocity to 0.1
+  slate.set_cmd_vel(0.0, 0.1);
+
+  while (true) {
+    // Update state to fetch fresh data from hardware
+    slate.update_state();
 
     // Output charge percentage
     std::cout << "Charge: " << slate.get_charge() << "%" << std::endl;

--- a/demo/reset_odom_demo.cpp
+++ b/demo/reset_odom_demo.cpp
@@ -58,7 +58,10 @@ int main()
 
   // Initialize base and output result
   std::string result_init;
-  slate.init_base(result_init);
+  if (!slate.init_base(result_init)) {
+    std::cerr << result_init << std::endl;
+    return 1;
+  }
   std::cout << result_init << std::endl;
 
   // Disable motor torque

--- a/demo/reset_odom_demo.cpp
+++ b/demo/reset_odom_demo.cpp
@@ -72,6 +72,7 @@ int main()
   // Print odometry before reset
   std::cout << "\n=== Odometry Before Reset ===" << std::endl;
   for (int i = 0; i < 5; i++) {
+    slate.update_state();
     std::array<float, 3> pose = slate.get_pose();
     std::cout
       << "X: " << pose[0]
@@ -86,6 +87,7 @@ int main()
   std::cin.get();
 
   // Print off odom before reset
+  slate.update_state();
   std::array<float, 3> pose_before = slate.get_pose();
   std::cout
     << "Odometry before reset - X: " << pose_before[0]
@@ -101,6 +103,7 @@ int main()
   // Continue printing odometry after reset
   std::cout << "\n=== Odometry After Reset ===" << std::endl;
   for (int i = 0; i < 10; i++) {
+    slate.update_state();
     std::array<float, 3> pose = slate.get_pose();
     std::cout
       << "X: " << pose[0]

--- a/package.xml
+++ b/package.xml
@@ -9,9 +9,10 @@
 
   <license>BSD-3-Clause</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
-  
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
+
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+    <build_type condition="$ROS_VERSION == ''">cmake</build_type>
   </export>
 </package>

--- a/src/trossen_slate.cpp
+++ b/src/trossen_slate.cpp
@@ -28,6 +28,8 @@
 
 #include "trossen_slate/trossen_slate.hpp"
 
+#include <stdexcept>
+
 namespace trossen_slate
 {
 


### PR DESCRIPTION
This PR does the following:
- On failure to detect `ament_cmake`, will use a pure CMake build
- Adds a conditional check to building demos
- Updates the package.xml to check for `ROS_VERSION` when declaring build tools and type
- Adds a makefile with targets for common operations
- General cleanup and improvements